### PR TITLE
Removed course-v4 repo

### DIFF
--- a/fastaionAMLCI.sh
+++ b/fastaionAMLCI.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 git clone https://github.com/fastai/fastai.git
 git clone https://github.com/fastai/fastbook.git
-git clone https://github.com/fastai/course-v4.git
 conda create -y --name fastaienv
 source /etc/profile.d/conda.sh
 conda activate fastaienv


### PR DESCRIPTION
Jemery from Fast AI: fyi we're not using the course-v4 repo any more. There's a "clean" folder with the same info in it. I'll update the course-v4 README to mention this.